### PR TITLE
Fix display issue where days planted and nutrient remaining days

### DIFF
--- a/custom_components/aerogarden/manifest.json
+++ b/custom_components/aerogarden/manifest.json
@@ -1,14 +1,12 @@
 {
   "domain": "aerogarden",
   "name": "Aerogarden",
-  "codeowners": [
-    "@dalinicus"
-  ],
+  "codeowners": ["@dalinicus"],
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/dalinicus/homeassistant-aerogarden",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/dalinicus/homeassistant-aerogarden/issues",
   "requirements": [],
-  "version": "1.4.0"
+  "version": "1.4.1"
 }

--- a/custom_components/aerogarden/sensor.py
+++ b/custom_components/aerogarden/sensor.py
@@ -48,7 +48,7 @@ SENSOR_DESCRIPTIONS: list[AerogardenSensorDescription] = [
         key=GARDEN_KEY_PLANTED_DAY,
         translation_key="planted_days",
         device_class=SensorDeviceClass.DURATION,
-        native_unit_of_measurement=UnitOfTime.DAYS,
+        unit_of_measurement=UnitOfTime.DAYS,
         icon="mdi:calendar",
         value_fn=lambda aerogarden, config_id: (
             aerogarden.get_garden_property(config_id, GARDEN_KEY_PLANTED_DAY)
@@ -58,7 +58,7 @@ SENSOR_DESCRIPTIONS: list[AerogardenSensorDescription] = [
         key=GARDEN_KEY_NUTRI_REMIND_DAY,
         translation_key="nutrient_days",
         device_class=SensorDeviceClass.DURATION,
-        native_unit_of_measurement=UnitOfTime.DAYS,
+        unit_of_measurement=UnitOfTime.DAYS,
         icon="mdi:calendar-clock",
         value_fn=lambda aerogarden, config_id: (
             aerogarden.get_garden_property(config_id, GARDEN_KEY_NUTRI_REMIND_DAY)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -172,7 +172,7 @@ class TestSensor:
         assert sensor.entity_description.translation_key == "planted_days"
         assert sensor.entity_description.icon == "mdi:calendar"
         assert sensor.entity_description.device_class == SensorDeviceClass.DURATION
-        assert sensor.entity_description.native_unit_of_measurement == UnitOfTime.DAYS
+        assert sensor.entity_description.unit_of_measurement == UnitOfTime.DAYS
         assert sensor.device_info is not None
         assert sensor.aerogarden is not None
         assert sensor.native_value == 43
@@ -185,7 +185,7 @@ class TestSensor:
         assert sensor.entity_description.translation_key == "nutrient_days"
         assert sensor.entity_description.icon == "mdi:calendar-clock"
         assert sensor.entity_description.device_class == SensorDeviceClass.DURATION
-        assert sensor.entity_description.native_unit_of_measurement == UnitOfTime.DAYS
+        assert sensor.entity_description.unit_of_measurement == UnitOfTime.DAYS
         assert sensor.device_info is not None
         assert sensor.aerogarden is not None
         assert sensor.native_value == 6


### PR DESCRIPTION
Fix display issue where days planted and nutrient remaining days were being displayed as hours (144:00:00) instead of days (6)

Seems like a bug in home-assistant core iteself when native_unit_of_messurement is supplied.  Issue does not manifest when only unit_of_messurement is supplied.